### PR TITLE
feat: add gender support and improve relationship handling

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { globalIgnores } from 'eslint/config'
 
 export default tseslint.config([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'prototype']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
-import { FamilyProvider, useFamilyContext } from './context/FamilyContext';
-import { PersonForm } from './components/PersonForm';
+import { FamilyProvider } from './context/FamilyContext';
 import { RelationshipManager } from './components/RelationshipManager';
 import { FamilyTree } from './components/FamilyTree';
 import Sidebar from './components/Sidebar';
@@ -11,14 +10,14 @@ const FamilyTreeApp: React.FC = () => {
   const [relationshipPerson, setRelationshipPerson] = useState<Person | undefined>();
 
   React.useEffect(() => {
-    const handleManageRelationshipsEvent = (event: any) => {
+    const handleManageRelationshipsEvent = (event: CustomEvent<Person>) => {
       setRelationshipPerson(event.detail);
     };
 
-    window.addEventListener('manageRelationships', handleManageRelationshipsEvent);
+    window.addEventListener('manageRelationships', handleManageRelationshipsEvent as EventListener);
 
     return () => {
-      window.removeEventListener('manageRelationships', handleManageRelationshipsEvent);
+      window.removeEventListener('manageRelationships', handleManageRelationshipsEvent as EventListener);
     };
   }, []);
 

--- a/src/components/CustomEdge.tsx
+++ b/src/components/CustomEdge.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getBezierPath } from '@xyflow/react';
+import { getBezierPath, Position } from '@xyflow/react';
 
 interface CustomEdgeProps {
   id: string;
@@ -7,8 +7,8 @@ interface CustomEdgeProps {
   sourceY: number;
   targetX: number;
   targetY: number;
-  sourcePosition: any;
-  targetPosition: any;
+  sourcePosition: Position;
+  targetPosition: Position;
   style?: React.CSSProperties;
   markerEnd?: string;
 }

--- a/src/components/FamilyTree.tsx
+++ b/src/components/FamilyTree.tsx
@@ -10,7 +10,7 @@ import {
   MarkerType,
   ReactFlowProvider,
 } from '@xyflow/react';
-import type { Node, Edge } from '@xyflow/react';
+import type { Node, Edge, ReactFlowInstance } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import type { Person } from '../types/Person';
 import { useFamilyContext } from '../context/FamilyContext';
@@ -33,10 +33,10 @@ const edgeTypes = {
 
 const FamilyTreeFlow: React.FC<FamilyTreeProps> = ({ focusPersonId }) => {
   const { people, getPersonById } = useFamilyContext();
-  const [reactFlowInstance, setReactFlowInstance] = useState<any>(null);
+  const [reactFlowInstance, setReactFlowInstance] = useState<ReactFlowInstance<Node<PersonNodeData>, Edge> | null>(null);
 
   const { nodes: initialNodes, edges: initialEdges } = useMemo(() => {
-    const nodes: any[] = [];
+    const nodes: Node<PersonNodeData>[] = [];
     const edges: Edge[] = [];
     const nodePositions = new Map<string, { x: number; y: number }>();
 
@@ -145,10 +145,10 @@ const FamilyTreeFlow: React.FC<FamilyTreeProps> = ({ focusPersonId }) => {
     return { nodes, edges };
   }, [people, focusPersonId, getPersonById]);
 
-  const [nodes, , onNodesChange] = useNodesState(initialNodes);
+  const [nodes, , onNodesChange] = useNodesState<Node<PersonNodeData>>(initialNodes);
   const [edges, , onEdgesChange] = useEdgesState(initialEdges);
 
-  const onInit = useCallback((instance: any) => {
+  const onInit = useCallback((instance: ReactFlowInstance<Node<PersonNodeData>, Edge>) => {
     setReactFlowInstance(instance);
     setTimeout(() => {
       instance.fitView({ padding: 0.2 });

--- a/src/components/PersonForm.tsx
+++ b/src/components/PersonForm.tsx
@@ -11,6 +11,7 @@ export const PersonForm: React.FC<PersonFormProps> = ({ person, onSubmit, onCanc
   const [formData, setFormData] = useState({
     firstName: person?.firstName || '',
     lastName: person?.lastName || '',
+    gender: person?.gender || 'other',
     birthDate: person?.birthDate || '',
     deathDate: person?.deathDate || '',
     notes: person?.notes || '',
@@ -56,7 +57,7 @@ export const PersonForm: React.FC<PersonFormProps> = ({ person, onSubmit, onCanc
     }
   };
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     const { name, value } = e.target;
     setFormData(prev => ({ ...prev, [name]: value }));
     
@@ -103,12 +104,12 @@ export const PersonForm: React.FC<PersonFormProps> = ({ person, onSubmit, onCanc
         
         {/* Form */}
         <form onSubmit={handleSubmit} className="p-6 space-y-6">
-          {/* Name fields */}
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label htmlFor="firstName" className="block text-sm font-semibold text-gray-700 mb-2">
-                First Name *
-              </label>
+            {/* Name fields */}
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="firstName" className="block text-sm font-semibold text-gray-700 mb-2">
+                  First Name *
+                </label>
               <input
                 type="text"
                 id="firstName"
@@ -163,8 +164,26 @@ export const PersonForm: React.FC<PersonFormProps> = ({ person, onSubmit, onCanc
                   {errors.lastName}
                 </p>
               )}
+              </div>
             </div>
-          </div>
+
+            {/* Gender field */}
+            <div>
+              <label htmlFor="gender" className="block text-sm font-semibold text-gray-700 mb-2">
+                Gender
+              </label>
+              <select
+                id="gender"
+                name="gender"
+                value={formData.gender}
+                onChange={handleChange}
+                className="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:outline-none focus:ring-4 focus:ring-blue-500 focus:ring-opacity-20 focus:border-blue-500 bg-gray-50 focus:bg-white transition-all duration-200"
+              >
+                <option value="male">Male</option>
+                <option value="female">Female</option>
+                <option value="other">Other</option>
+              </select>
+            </div>
 
           {/* Date fields */}
           <div className="grid grid-cols-2 gap-4">

--- a/src/components/PersonFormInline.tsx
+++ b/src/components/PersonFormInline.tsx
@@ -11,6 +11,7 @@ export const PersonFormInline: React.FC<PersonFormInlineProps> = ({ person, onSu
   const [formData, setFormData] = useState({
     firstName: person?.firstName || '',
     lastName: person?.lastName || '',
+    gender: person?.gender || 'other',
     birthDate: person?.birthDate || '',
     deathDate: person?.deathDate || '',
     notes: person?.notes || '',
@@ -23,18 +24,19 @@ export const PersonFormInline: React.FC<PersonFormInlineProps> = ({ person, onSu
 
   useEffect(() => {
     if (person) {
-      setFormData({
-        firstName: person.firstName || '',
-        lastName: person.lastName || '',
-        birthDate: person.birthDate || '',
-        deathDate: person.deathDate || '',
-        notes: person.notes || '',
-        parentIds: person.parentIds || [],
-        spouseIds: person.spouseIds || [],
-        childrenIds: person.childrenIds || [],
-      });
-    }
-  }, [person]);
+        setFormData({
+          firstName: person.firstName || '',
+          lastName: person.lastName || '',
+          gender: person.gender || 'other',
+          birthDate: person.birthDate || '',
+          deathDate: person.deathDate || '',
+          notes: person.notes || '',
+          parentIds: person.parentIds || [],
+          spouseIds: person.spouseIds || [],
+          childrenIds: person.childrenIds || [],
+        });
+      }
+    }, [person]);
 
   const validateForm = () => {
     const newErrors: { [key: string]: string } = {};
@@ -66,7 +68,7 @@ export const PersonFormInline: React.FC<PersonFormInlineProps> = ({ person, onSu
     }
   };
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     const { name, value } = e.target;
     setFormData(prev => ({ ...prev, [name]: value }));
     
@@ -79,11 +81,11 @@ export const PersonFormInline: React.FC<PersonFormInlineProps> = ({ person, onSu
   return (
     <div className="space-y-4">
       <form onSubmit={handleSubmit} className="space-y-4">
-        {/* Name fields */}
-        <div>
-          <label htmlFor="firstName" className="block text-xs font-medium text-gray-700 mb-1">
-            First Name *
-          </label>
+          {/* Name fields */}
+          <div>
+            <label htmlFor="firstName" className="block text-xs font-medium text-gray-700 mb-1">
+              First Name *
+            </label>
           <input
             type="text"
             id="firstName"
@@ -103,12 +105,12 @@ export const PersonFormInline: React.FC<PersonFormInlineProps> = ({ person, onSu
           {errors.firstName && (
             <p className="mt-1 text-xs text-red-600">{errors.firstName}</p>
           )}
-        </div>
+          </div>
 
-        <div>
-          <label htmlFor="lastName" className="block text-xs font-medium text-gray-700 mb-1">
-            Last Name *
-          </label>
+          <div>
+            <label htmlFor="lastName" className="block text-xs font-medium text-gray-700 mb-1">
+              Last Name *
+            </label>
           <input
             type="text"
             id="lastName"
@@ -125,16 +127,34 @@ export const PersonFormInline: React.FC<PersonFormInlineProps> = ({ person, onSu
             `}
             placeholder="Enter last name"
           />
-          {errors.lastName && (
-            <p className="mt-1 text-xs text-red-600">{errors.lastName}</p>
-          )}
-        </div>
+            {errors.lastName && (
+              <p className="mt-1 text-xs text-red-600">{errors.lastName}</p>
+            )}
+          </div>
+
+          {/* Gender field */}
+          <div>
+            <label htmlFor="gender" className="block text-xs font-medium text-gray-700 mb-1">
+              Gender
+            </label>
+            <select
+              id="gender"
+              name="gender"
+              value={formData.gender}
+              onChange={handleChange}
+              className="w-full px-3 py-2 text-sm border border-gray-200 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-20 focus:border-blue-500 bg-white transition-colors"
+            >
+              <option value="male">Male</option>
+              <option value="female">Female</option>
+              <option value="other">Other</option>
+            </select>
+          </div>
 
         {/* Date fields */}
-        <div>
-          <label htmlFor="birthDate" className="block text-xs font-medium text-gray-700 mb-1">
-            Birth Date
-          </label>
+          <div>
+            <label htmlFor="birthDate" className="block text-xs font-medium text-gray-700 mb-1">
+              Birth Date
+            </label>
           <input
             type="date"
             id="birthDate"

--- a/src/components/PersonNode.tsx
+++ b/src/components/PersonNode.tsx
@@ -33,23 +33,35 @@ const PersonNode: React.FC<PersonNodeProps> = ({ data, selected }) => {
 
   const age = calculateAge(person);
 
-  return (
-    <div 
-      className={`
-        bg-white border-2 rounded-xl p-3 shadow-lg min-w-[200px] max-w-[220px]
-        transition-all duration-200
-        ${selected ? 'border-blue-500 shadow-blue-200' : 'border-gray-200 hover:border-blue-300'}
-        ${person.deathDate ? 'opacity-75' : ''}
-      `}
-    >
+    const borderClasses = person.gender === 'female'
+      ? selected ? 'border-pink-500 shadow-pink-200' : 'border-pink-300 hover:border-pink-400'
+      : person.gender === 'male'
+        ? selected ? 'border-blue-500 shadow-blue-200' : 'border-blue-300 hover:border-blue-400'
+        : selected ? 'border-gray-500 shadow-gray-200' : 'border-gray-300 hover:border-gray-400';
+
+    const avatarClasses = person.gender === 'female'
+      ? 'bg-pink-100 text-pink-500'
+      : person.gender === 'male'
+        ? 'bg-blue-100 text-blue-500'
+        : 'bg-gray-100 text-gray-500';
+
+    return (
+      <div
+        className={`
+          bg-white border-2 rounded-xl p-3 shadow-lg min-w-[200px] max-w-[220px]
+          transition-all duration-200
+          ${borderClasses}
+          ${person.deathDate ? 'opacity-75' : ''}
+        `}
+      >
       {/* Handles for connections */}
       <Handle type="target" position={Position.Top} className="w-3 h-3" />
       <Handle type="source" position={Position.Bottom} className="w-3 h-3" />
       
       <div className="flex items-start gap-3">
-        <div className="w-10 h-10 rounded-full flex items-center justify-center bg-blue-100">
-          <UserIcon size={20} className="text-blue-500" />
-        </div>
+          <div className={`w-10 h-10 rounded-full flex items-center justify-center ${avatarClasses}`}>
+            <UserIcon size={20} />
+          </div>
         
         <div className="flex-1 min-w-0">
           <h3 className="font-semibold text-sm text-gray-900 truncate">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -24,17 +24,17 @@ const Sidebar: React.FC<SidebarProps> = ({
   const { people, addPerson, updatePerson } = useFamilyContext();
 
   // Listen for edit person events from tree nodes
-  React.useEffect(() => {
-    const handleEditPersonEvent = (event: any) => {
-      setEditingPerson(event.detail);
-      setActiveTab('add-person');
-    };
+    React.useEffect(() => {
+      const handleEditPersonEvent = (event: CustomEvent<Person>) => {
+        setEditingPerson(event.detail);
+        setActiveTab('add-person');
+      };
 
-    window.addEventListener('editPerson', handleEditPersonEvent);
+      window.addEventListener('editPerson', handleEditPersonEvent as EventListener);
 
-    return () => {
-      window.removeEventListener('editPerson', handleEditPersonEvent);
-    };
+      return () => {
+        window.removeEventListener('editPerson', handleEditPersonEvent as EventListener);
+      };
   }, []);
 
   const handleEditPerson = (person: Person, e: React.MouseEvent) => {
@@ -120,32 +120,39 @@ const Sidebar: React.FC<SidebarProps> = ({
                   Family Members
                 </h3>
                 <div className="space-y-1">
-                  {people.map(person => (
-                    <div 
-                      key={person.id} 
-                      className={`p-2 rounded-md cursor-pointer flex items-center gap-3 ${selectedPerson?.id === person.id ? 'bg-blue-50 text-blue-700' : 'hover:bg-gray-100'}`} 
-                      onClick={() => setSelectedPerson(person)}
-                    >
-                      <div className="w-8 h-8 rounded-full flex items-center justify-center bg-blue-100">
-                        <UsersIcon size={16} className="text-blue-500" />
-                      </div>
-                      <div className="flex-1">
-                        <p className="text-sm font-medium">{person.firstName} {person.lastName}</p>
-                        {person.birthDate && (
-                          <p className="text-xs text-gray-500">
-                            b. {new Date(person.birthDate).getFullYear()}
-                          </p>
-                        )}
-                      </div>
-                      <button 
-                        onClick={(e) => handleEditPerson(person, e)} 
-                        className="p-1 text-gray-400 hover:text-blue-500 hover:bg-blue-50 rounded-full"
-                      >
-                        <EditIcon size={16} />
-                      </button>
-                    </div>
-                  ))}
-                </div>
+                    {people.map(person => {
+                      const avatarClasses = person.gender === 'female'
+                        ? 'bg-pink-100 text-pink-500'
+                        : person.gender === 'male'
+                          ? 'bg-blue-100 text-blue-500'
+                          : 'bg-gray-100 text-gray-500';
+                      return (
+                        <div
+                          key={person.id}
+                          className={`p-2 rounded-md cursor-pointer flex items-center gap-3 ${selectedPerson?.id === person.id ? 'bg-blue-50 text-blue-700' : 'hover:bg-gray-100'}`}
+                          onClick={() => setSelectedPerson(person)}
+                        >
+                          <div className={`w-8 h-8 rounded-full flex items-center justify-center ${avatarClasses}`}>
+                            <UsersIcon size={16} />
+                          </div>
+                          <div className="flex-1">
+                            <p className="text-sm font-medium">{person.firstName} {person.lastName}</p>
+                            {person.birthDate && (
+                              <p className="text-xs text-gray-500">
+                                b. {new Date(person.birthDate).getFullYear()}
+                              </p>
+                            )}
+                          </div>
+                          <button
+                            onClick={(e) => handleEditPerson(person, e)}
+                            className="p-1 text-gray-400 hover:text-blue-500 hover:bg-blue-50 rounded-full"
+                          >
+                            <EditIcon size={16} />
+                          </button>
+                        </div>
+                      );
+                    })}
+                  </div>
                 
                 <button 
                   className="w-full mt-4 py-2 flex items-center justify-center gap-2 text-sm text-blue-600 hover:bg-blue-50 rounded-md border border-blue-200" 

--- a/src/context/FamilyContext.tsx
+++ b/src/context/FamilyContext.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import React, { createContext, useContext, useState, useEffect, type ReactNode } from 'react';
 import type { Person } from '../types/Person';
 import { loadPeople, savePeople, generateId } from '../utils/storage';
@@ -32,15 +33,11 @@ export const FamilyProvider: React.FC<FamilyProviderProps> = ({ children }) => {
 
   useEffect(() => {
     const savedPeople = loadPeople();
-    console.log('Loading people from localStorage:', savedPeople);
     setPeople(savedPeople);
   }, []);
 
   useEffect(() => {
-    if (people.length > 0) {
-      console.log('Saving people to localStorage:', people);
-      savePeople(people);
-    }
+    savePeople(people);
   }, [people]);
 
   const addPerson = (personData: Omit<Person, 'id'>) => {
@@ -70,22 +67,24 @@ export const FamilyProvider: React.FC<FamilyProviderProps> = ({ children }) => {
   };
 
   const addRelationship = (personId: string, relatedPersonId: string, type: 'parent' | 'spouse' | 'child') => {
+    if (personId === relatedPersonId) return;
+
     setPeople(prev => prev.map(person => {
       if (person.id === personId) {
-        if (type === 'parent') {
+        if (type === 'parent' && !person.parentIds.includes(relatedPersonId)) {
           return { ...person, parentIds: [...person.parentIds, relatedPersonId] };
-        } else if (type === 'spouse') {
+        } else if (type === 'spouse' && !person.spouseIds.includes(relatedPersonId)) {
           return { ...person, spouseIds: [...person.spouseIds, relatedPersonId] };
-        } else if (type === 'child') {
+        } else if (type === 'child' && !person.childrenIds.includes(relatedPersonId)) {
           return { ...person, childrenIds: [...person.childrenIds, relatedPersonId] };
         }
       }
       if (person.id === relatedPersonId) {
-        if (type === 'parent') {
+        if (type === 'parent' && !person.childrenIds.includes(personId)) {
           return { ...person, childrenIds: [...person.childrenIds, personId] };
-        } else if (type === 'spouse') {
+        } else if (type === 'spouse' && !person.spouseIds.includes(personId)) {
           return { ...person, spouseIds: [...person.spouseIds, personId] };
-        } else if (type === 'child') {
+        } else if (type === 'child' && !person.parentIds.includes(personId)) {
           return { ...person, parentIds: [...person.parentIds, personId] };
         }
       }

--- a/src/types/Person.ts
+++ b/src/types/Person.ts
@@ -2,6 +2,7 @@ export type Person = {
   id: string;
   firstName: string;
   lastName: string;
+  gender?: 'male' | 'female' | 'other';
   birthDate?: string;
   deathDate?: string;
   photo?: string;

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -21,5 +21,8 @@ export const savePeople = (people: Person[]): void => {
 };
 
 export const generateId = (): string => {
-  return Date.now().toString(36) + Math.random().toString(36).substr(2);
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return Date.now().toString(36) + Math.random().toString(36).substring(2);
 };


### PR DESCRIPTION
## Summary
- add optional gender field to people and color-coded node/UI elements
- prevent duplicate/self relationships and persist deletions to localStorage
- use `crypto.randomUUID` for ids and ignore prototype folder in lint config

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a67a8fe104832f9498d293b63b6693